### PR TITLE
Fix the hostname for the dashboard app

### DIFF
--- a/packages/dashboard-app/.env
+++ b/packages/dashboard-app/.env
@@ -1,2 +1,2 @@
 REACT_APP_CUBEJS_TOKEN=changethistosomethingelse
-REACT_APP_API_URL=https://${hostname}-4000.preview.csb.app/cubejs-api/v1
+REACT_APP_API_URL=https://${HOSTNAME}-4000.preview.csb.app/cubejs-api/v1


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/codesandbox-template-cubejs/draft/async-fire?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=codesandbox-template-cubejs&branch=draft/async-fire">VS Code</a>

<!-- open-in-codesandbox:complete -->


In the VMs the default hostname env var has been changed so make sure this template is using the right one.